### PR TITLE
Add simple Ubuntu server

### DIFF
--- a/mlox/servers/ubuntu/simple.py
+++ b/mlox/servers/ubuntu/simple.py
@@ -1,0 +1,63 @@
+import logging
+
+from dataclasses import dataclass
+from typing import Dict, Any
+
+from mlox.servers.ubuntu.native import UbuntuNativeServer
+from mlox.server import RemoteUser
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class UbuntuSimpleServer(UbuntuNativeServer):
+    """A minimal Ubuntu server that assumes access is already configured.
+
+    No package installation, user creation or system updates are performed.
+    The server can optionally connect using an existing SSH private key.
+    """
+
+    root_private_key: str | None = None
+    root_passphrase: str | None = None
+
+    def __post_init__(self):
+        super().__post_init__()
+        if self.root_private_key:
+            remote = RemoteUser(ssh_passphrase=self.root_passphrase or "")
+            remote.ssh_key = self.root_private_key
+            self.remote_user = remote
+
+    def setup(self) -> None:
+        if self.state != "un-initialized":
+            logging.error("Can not initialize an already initialized server.")
+            return
+        self.state = "starting"
+        self.setup_backend()
+
+    # The following methods are intentionally no-ops to keep the server minimal
+    def update(self) -> None:
+        logger.info("Skipping update for UbuntuSimpleServer.")
+
+    def install_packages(self) -> None:
+        logger.info("Skipping package installation for UbuntuSimpleServer.")
+
+    def add_mlox_user(self) -> None:
+        logger.info("Skipping mlox user creation for UbuntuSimpleServer.")
+
+    def setup_users(self) -> None:
+        logger.info("Skipping user setup for UbuntuSimpleServer.")
+
+    def disable_password_authentication(self) -> None:
+        logger.info("Skipping password authentication configuration for UbuntuSimpleServer.")
+
+    def enable_password_authentication(self) -> None:
+        logger.info("Skipping password authentication configuration for UbuntuSimpleServer.")
+
+    def enable_debug_access(self) -> None:
+        self.is_debug_access_enabled = True
+
+    def disable_debug_access(self) -> None:
+        self.is_debug_access_enabled = False
+
+    def get_backend_status(self) -> Dict[str, Any]:
+        return super().get_backend_status()

--- a/mlox/servers/ubuntu/ui_simple.py
+++ b/mlox/servers/ubuntu/ui_simple.py
@@ -1,0 +1,79 @@
+import streamlit as st
+
+from typing import Dict
+
+from mlox.config import ServiceConfig
+from mlox.infra import Infrastructure, Bundle
+from mlox.servers.ubuntu.simple import UbuntuSimpleServer
+
+
+def form_add_server():
+    c1, c2 = st.columns(2)
+    ip = c1.text_input(
+        "IP Address",
+        placeholder="Enter the server IP address",
+        help="The IP address of the server you want to add.",
+    )
+    port = c2.number_input(
+        "SSH Port",
+        value=22,
+        min_value=1,
+        max_value=65535,
+        step=1,
+        placeholder="Enter the server SSH port",
+        help="The SSH port for the server.",
+    )
+    user = c1.text_input(
+        "Account Name",
+        value="root",
+        placeholder="Enter the server account name",
+        help="Account with existing access to the server.",
+    )
+    pw = c2.text_input(
+        "Account Password",
+        value="",
+        placeholder="Enter the server password (optional)",
+        help="Password for the account, if required.",
+        type="password",
+    )
+    private_key = c1.text_area(
+        "Private Key",
+        placeholder="Paste the SSH private key (optional)",
+        help="Private key for SSH authentication.",
+    )
+    passphrase = c2.text_input(
+        "Private Key Passphrase",
+        value="",
+        placeholder="Enter passphrase if the key is encrypted",
+        help="Passphrase protecting the private key (optional).",
+        type="password",
+    )
+    return ip, port, user, pw, private_key, passphrase
+
+
+def setup(infra: Infrastructure, config: ServiceConfig) -> Dict:
+    params = dict()
+
+    ip, port, user, pw, private_key, passphrase = form_add_server()
+
+    params["${MLOX_IP}"] = ip
+    params["${MLOX_PORT}"] = str(port)
+    params["${MLOX_ROOT}"] = user
+    params["${MLOX_ROOT_PW}"] = pw
+    params["${MLOX_ROOT_PRIVATE_KEY}"] = private_key
+    params["${MLOX_ROOT_PASSPHRASE}"] = passphrase
+
+    return params
+
+
+def settings(infra: Infrastructure, bundle: Bundle, server: UbuntuSimpleServer):
+    if server.state != "running":
+        st.markdown("Server is not running. Please start the server first.")
+        return
+
+    tab_server, tab_backend = st.tabs(["Server Info", "Backend Status"])
+    with tab_server:
+        st.write(server.get_server_info())
+
+    with tab_backend:
+        st.write(server.get_backend_status())

--- a/mlox/stacks/ubuntu/mlox-server.ubuntu.simple.yaml
+++ b/mlox/stacks/ubuntu/mlox-server.ubuntu.simple.yaml
@@ -1,0 +1,32 @@
+id: ubuntu-simple-24.04-server
+name: Ubuntu (Simple)
+version: 24.04
+maintainer: Your Name
+description_short: Ubuntu with pre-configured access.
+description: |
+  Ubuntu is a popular Linux distribution based on Debian.
+  This stack assumes the server already has an accessible user via password or SSH key.
+links:
+  project: https://ubuntu.com/
+  news: https://ubuntu.com/
+  security: https://ubuntu.com/
+  documentation: https://ubuntu.com/
+  changelog: https://ubuntu.com/
+groups:
+  server:
+    git:
+    initial_auth_password:
+  backend:
+    native:
+ui:
+  setup: mlox.servers.ubuntu.ui_simple.setup
+  settings: mlox.servers.ubuntu.ui_simple.settings
+build:
+  class_name: mlox.servers.ubuntu.simple.UbuntuSimpleServer
+  params:
+    ip: ${MLOX_IP}
+    port: ${MLOX_PORT}
+    root: ${MLOX_ROOT}
+    root_pw: ${MLOX_ROOT_PW}
+    root_private_key: ${MLOX_ROOT_PRIVATE_KEY}
+    root_passphrase: ${MLOX_ROOT_PASSPHRASE}


### PR DESCRIPTION
## Summary
- add `UbuntuSimpleServer` that assumes pre-configured access without package or user setup
- provide minimal Streamlit UI for specifying existing credentials or SSH key
- include stack configuration for the new simple server variant

## Testing
- `pytest` *(fails: No module named 'multipass', 'fabric', 'mlox', 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68c3c544f8148322ba096fcba2d3c3af