### PR TITLE
feat: show infrastructure servers and services in textual UI

### DIFF
--- a/mlox/tui.tcss
+++ b/mlox/tui.tcss
@@ -66,3 +66,24 @@ Button {
   color: #ff6b6b;
   margin-top: 1;
 }
+
+#main-area {
+  layout: horizontal;
+}
+
+#sidebar {
+  width: 30;
+  border: round #2b3c5f;
+}
+
+#content {
+  width: 1fr;
+}
+
+Tree {
+  height: 100%;
+}
+
+DataTable {
+  height: 100%;
+}


### PR DESCRIPTION
## Summary
- Add tree-based sidebar navigation and tabs for Home, Servers and Services
- Display infrastructure server and service lists using DataTables
- Style TUI main layout with horizontal sidebar/content arrangement

## Testing
- `pytest` *(fails: No module named 'multipass')*


------
https://chatgpt.com/codex/tasks/task_e_68c3c759bdd88322aa195ff8d4af3242