### PR TITLE
Add Harbor service with TLS docker stack

### DIFF
--- a/mlox/services/harbor/__init__.py
+++ b/mlox/services/harbor/__init__.py
@@ -1,0 +1,1 @@
+"""Harbor container registry service integration."""

--- a/mlox/services/harbor/docker-compose-harbor.yaml
+++ b/mlox/services/harbor/docker-compose-harbor.yaml
@@ -1,0 +1,180 @@
+version: "3.8"
+
+services:
+  harbor-log:
+    image: goharbor/harbor-log:v2.14.0
+    container_name: harbor-log
+    restart: unless-stopped
+    volumes:
+      - ./data/log:/var/log/docker
+    networks:
+      - harbor
+
+  harbor-db:
+    image: goharbor/harbor-db:v2.14.0
+    container_name: harbor-db
+    restart: unless-stopped
+    environment:
+      POSTGRESQL_PASSWORD: ${HARBOR_DATABASE_PASSWORD:-HarborDB123}
+      POSTGRESQL_USERNAME: postgres
+      POSTGRESQL_DATABASE: registry
+      POSTGRESQL_SSLMODE: disable
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    networks:
+      - harbor
+
+  harbor-redis:
+    image: goharbor/redis-photon:v2.14.0
+    container_name: harbor-redis
+    restart: unless-stopped
+    command: ["redis-server", "--requirepass", "${HARBOR_REDIS_PASSWORD:-HarborRedis123}"]
+    volumes:
+      - redis-data:/var/lib/redis
+    networks:
+      - harbor
+
+  harbor-registry:
+    image: goharbor/registry-photon:v2.14.0
+    container_name: harbor-registry
+    depends_on:
+      - harbor-log
+    environment:
+      REGISTRY_HTTP_ADDR: 0.0.0.0:5000
+      REGISTRY_HTTP_TLS_CERTIFICATE: /etc/harbor/ssl/harbor.crt
+      REGISTRY_HTTP_TLS_KEY: /etc/harbor/ssl/harbor.key
+      REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY: /storage
+      REGISTRY_STORAGE_DELETE_ENABLED: "true"
+      REGISTRY_AUTH_TOKEN_REALM: https://${HARBOR_HOSTNAME}:${HARBOR_HTTPS_PORT}/service/token
+      REGISTRY_AUTH_TOKEN_SERVICE: harbor-registry
+      REGISTRY_AUTH_TOKEN_ISSUER: harbor-token-issuer
+      REGISTRY_AUTH_TOKEN_ROOTCERTBUNDLE: /etc/harbor/ssl/harbor.crt
+      REGISTRY_HTTP_SECRET: ${HARBOR_REGISTRY_HTTP_SECRET:-harborregistrysecret}
+    volumes:
+      - registry-data:/storage
+      - ./cert.pem:/etc/harbor/ssl/harbor.crt:ro
+      - ./key.pem:/etc/harbor/ssl/harbor.key:ro
+    networks:
+      - harbor
+
+  harbor-registryctl:
+    image: goharbor/harbor-registryctl:v2.14.0
+    container_name: harbor-registryctl
+    depends_on:
+      - harbor-registry
+    environment:
+      REGISTRY_CONTROLLER_PORT: "8080"
+      CORE_SECRET: ${HARBOR_CORE_SECRET:-harborcoresecret}
+      JOBSERVICE_SECRET: ${HARBOR_JOBSERVICE_SECRET:-harborjobsecret}
+      REGISTRY_HTTP_SECRET: ${HARBOR_REGISTRY_HTTP_SECRET:-harborregistrysecret}
+      REGISTRY_CONTROLLER_URL: http://harbor-registryctl:8080
+      REGISTRY_URL: http://harbor-registry:5000
+    volumes:
+      - ./cert.pem:/etc/harbor/ssl/harbor.crt:ro
+      - ./key.pem:/etc/harbor/ssl/harbor.key:ro
+    networks:
+      - harbor
+
+  harbor-portal:
+    image: goharbor/harbor-portal:v2.14.0
+    container_name: harbor-portal
+    depends_on:
+      - harbor-log
+    restart: unless-stopped
+    networks:
+      - harbor
+
+  harbor-core:
+    image: goharbor/harbor-core:v2.14.0
+    container_name: harbor-core
+    depends_on:
+      - harbor-db
+      - harbor-redis
+      - harbor-registry
+      - harbor-registryctl
+      - harbor-portal
+    environment:
+      PORTAL_URL: https://${HARBOR_HOSTNAME}:${HARBOR_HTTPS_PORT}
+      REGISTRY_URL: http://harbor-registry:5000
+      REGISTRY_CONTROLLER_URL: http://harbor-registryctl:8080
+      TOKEN_SERVICE_URL: https://${HARBOR_HOSTNAME}:${HARBOR_HTTPS_PORT}/service/token
+      CORE_SECRET: ${HARBOR_CORE_SECRET:-harborcoresecret}
+      JOBSERVICE_SECRET: ${HARBOR_JOBSERVICE_SECRET:-harborjobsecret}
+      REGISTRY_HTTP_SECRET: ${HARBOR_REGISTRY_HTTP_SECRET:-harborregistrysecret}
+      DATABASE_TYPE: postgresql
+      POSTGRESQL_HOST: harbor-db
+      POSTGRESQL_PORT: 5432
+      POSTGRESQL_USERNAME: postgres
+      POSTGRESQL_PASSWORD: ${HARBOR_DATABASE_PASSWORD:-HarborDB123}
+      POSTGRESQL_DATABASE: registry
+      REDIS_URL: redis://:${HARBOR_REDIS_PASSWORD:-HarborRedis123}@harbor-redis:6379/1
+      HARBOR_ADMIN_USERNAME: ${HARBOR_ADMIN_USERNAME:-admin}
+      HARBOR_ADMIN_PASSWORD: ${HARBOR_ADMIN_PASSWORD:-Harbor12345}
+      ADMIRAL_URL: ""
+      REGISTRY_CREDENTIAL_USERNAME: ${HARBOR_ADMIN_USERNAME:-admin}
+      REGISTRY_CREDENTIAL_PASSWORD: ${HARBOR_ADMIN_PASSWORD:-Harbor12345}
+      WITH_TRIVY: "true"
+      CHARTMUSEUM_ENABLED: "false"
+      NOTARY_ENABLED: "false"
+    volumes:
+      - ./harbor.yml:/etc/harbor/harbor.yml:ro
+      - ./cert.pem:/etc/harbor/tls/harbor.crt:ro
+      - ./key.pem:/etc/harbor/tls/harbor.key:ro
+      - core-data:/data
+    networks:
+      - harbor
+
+  harbor-jobservice:
+    image: goharbor/harbor-jobservice:v2.14.0
+    container_name: harbor-jobservice
+    depends_on:
+      - harbor-core
+      - harbor-redis
+    environment:
+      CORE_SECRET: ${HARBOR_CORE_SECRET:-harborcoresecret}
+      JOBSERVICE_SECRET: ${HARBOR_JOBSERVICE_SECRET:-harborjobsecret}
+      REDIS_URL: redis://:${HARBOR_REDIS_PASSWORD:-HarborRedis123}@harbor-redis:6379/1
+      REGISTRY_URL: http://harbor-registry:5000
+      REGISTRY_CONTROLLER_URL: http://harbor-registryctl:8080
+    volumes:
+      - jobservice-data:/var/log/jobservice
+    networks:
+      - harbor
+
+  harbor-trivy:
+    image: goharbor/trivy-adapter-photon:v2.14.0
+    container_name: harbor-trivy
+    depends_on:
+      - harbor-core
+    environment:
+      SCANNER_LOG_LEVEL: info
+      TZ: UTC
+    networks:
+      - harbor
+
+  harbor-nginx:
+    image: goharbor/nginx-photon:v2.14.0
+    container_name: harbor-nginx
+    depends_on:
+      - harbor-core
+      - harbor-portal
+    ports:
+      - ${HARBOR_HTTPS_PORT:-8443}:8443
+      - ${HARBOR_REGISTRY_PORT:-5443}:5443
+    volumes:
+      - ./harbor.yml:/etc/harbor/harbor.yml:ro
+      - ./cert.pem:/etc/harbor/tls/harbor.crt:ro
+      - ./key.pem:/etc/harbor/tls/harbor.key:ro
+    networks:
+      - harbor
+
+volumes:
+  db-data:
+  redis-data:
+  registry-data:
+  core-data:
+  jobservice-data:
+
+networks:
+  harbor:
+    driver: bridge

--- a/mlox/services/harbor/docker.py
+++ b/mlox/services/harbor/docker.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict
+
+from mlox.service import AbstractService
+
+
+@dataclass
+class HarborDockerService(AbstractService):
+    """Manage a self-hosted Harbor registry via Docker Compose."""
+
+    hostname: str
+    https_port: str | int
+    registry_port: str | int
+    admin_username: str
+    admin_password: str
+    database_password: str
+    redis_password: str
+    core_secret: str
+    jobservice_secret: str
+    registry_http_secret: str
+
+    service_url: str = field(init=False, default="")
+    registry_url: str = field(init=False, default="")
+    compose_service_names: Dict[str, str] = field(
+        init=False,
+        default_factory=lambda: {
+            "Harbor Nginx": "harbor-nginx",
+            "Harbor Core": "harbor-core",
+            "Harbor Jobservice": "harbor-jobservice",
+            "Harbor Portal": "harbor-portal",
+            "Harbor Registry": "harbor-registry",
+            "Harbor Database": "harbor-db",
+        },
+    )
+
+    def __post_init__(self) -> None:
+        self.https_port = int(self.https_port)
+        self.registry_port = int(self.registry_port)
+        self.service_ports["Harbor HTTPS"] = self.https_port
+        self.service_ports["Harbor Registry"] = self.registry_port
+        self.service_url = f"https://{self.hostname}:{self.https_port}"
+        self.registry_url = f"https://{self.hostname}:{self.registry_port}"
+        self.service_urls["Harbor UI"] = self.service_url
+        self.service_urls["Harbor Registry"] = self.registry_url
+
+    # ---- lifecycle -----------------------------------------------------
+    def setup(self, conn) -> None:
+        self.exec.fs_create_dir(conn, self.target_path)
+        self.exec.fs_copy(
+            conn, self.template, f"{self.target_path}/{self.target_docker_script}"
+        )
+
+        tls_host = self.hostname or getattr(conn, "host", "localhost")
+        self.hostname = tls_host
+        self.service_url = f"https://{tls_host}:{self.https_port}"
+        self.registry_url = f"https://{tls_host}:{self.registry_port}"
+        self.service_urls["Harbor UI"] = self.service_url
+        self.service_urls["Harbor Registry"] = self.registry_url
+        self.exec.fs_create_dir(conn, f"{self.target_path}/data/log")
+        self.exec.tls_setup(conn, tls_host, self.target_path)
+        self.certificate = self.exec.fs_read_file(
+            conn, f"{self.target_path}/cert.pem", format="txt/plain"
+        )
+
+        env_path = f"{self.target_path}/{self.target_docker_env}"
+        self.exec.fs_create_empty_file(conn, env_path)
+        for key, value in self._environment_variables(conn).items():
+            self.exec.fs_append_line(conn, env_path, f"{key}={value}")
+
+        self.exec.fs_write_file(
+            conn,
+            f"{self.target_path}/harbor.yml",
+            self._render_harbor_configuration(),
+        )
+
+    def teardown(self, conn) -> None:
+        self.exec.docker_down(
+            conn,
+            f"{self.target_path}/{self.target_docker_script}",
+            remove_volumes=True,
+        )
+        self.exec.fs_delete_dir(conn, self.target_path)
+
+    def spin_up(self, conn) -> bool:
+        return self.compose_up(conn)
+
+    def spin_down(self, conn) -> bool:
+        return self.compose_down(conn)
+
+    # ---- health -------------------------------------------------------
+    def check(self, conn) -> Dict:
+        try:
+            statuses = self.compose_service_status(conn)
+        except Exception:
+            self.state = "unknown"
+            return {"status": "unknown"}
+
+        if not statuses:
+            self.state = "stopped"
+            return {"status": "stopped"}
+
+        if all(state and "running" in state.lower() for state in statuses.values()):
+            self.state = "running"
+            return {"status": "running", "services": statuses}
+
+        if any(state and "running" in state.lower() for state in statuses.values()):
+            self.state = "running"
+            return {"status": "running", "services": statuses}
+
+        self.state = "unknown"
+        return {"status": "unknown", "services": statuses}
+
+    # ---- secrets ------------------------------------------------------
+    def get_secrets(self) -> Dict[str, Dict]:
+        secrets: Dict[str, Dict] = {}
+        if self.admin_username and self.admin_password:
+            secrets["harbor_admin_credentials"] = {
+                "username": self.admin_username,
+                "password": self.admin_password,
+            }
+        secrets["harbor_registry"] = {
+            "hostname": self.hostname,
+            "registry_url": self.registry_url,
+            "certificate": self.certificate or "",
+        }
+        return secrets
+
+    # ---- helpers ------------------------------------------------------
+    def _environment_variables(self, conn) -> Dict[str, str]:
+        host = self.hostname or getattr(conn, "host", "localhost")
+        return {
+            "HARBOR_HOSTNAME": host,
+            "HARBOR_HTTPS_PORT": str(self.https_port),
+            "HARBOR_REGISTRY_PORT": str(self.registry_port),
+            "HARBOR_ADMIN_USERNAME": self.admin_username,
+            "HARBOR_ADMIN_PASSWORD": self.admin_password,
+            "HARBOR_DATABASE_PASSWORD": self.database_password,
+            "HARBOR_REDIS_PASSWORD": self.redis_password,
+            "HARBOR_CORE_SECRET": self.core_secret,
+            "HARBOR_JOBSERVICE_SECRET": self.jobservice_secret,
+            "HARBOR_REGISTRY_HTTP_SECRET": self.registry_http_secret,
+            "HARBOR_TLS_CERT_PATH": "./cert.pem",
+            "HARBOR_TLS_KEY_PATH": "./key.pem",
+            "HARBOR_CONFIG_PATH": "./harbor.yml",
+        }
+
+    def _render_harbor_configuration(self) -> str:
+        return (
+            "\n".join(
+                [
+                    f"hostname: {self.hostname}",
+                    "http:",
+                    "  port: 80",
+                    "https:",
+                    f"  port: {self.https_port}",
+                    "  certificate: /etc/harbor/tls/harbor.crt",
+                    "  private_key: /etc/harbor/tls/harbor.key",
+                    f"harbor_admin_password: {self.admin_password}",
+                    "data_volume: /data",
+                    "database:",
+                    f"  password: {self.database_password}",
+                    "  max_idle_conns: 100",
+                    "  max_open_conns: 900",
+                    "redis:",
+                    f"  password: {self.redis_password}",
+                    "jobservice:",
+                    "  max_job_workers: 10",
+                    "log:",
+                    "  level: info",
+                    "notification:",
+                    "  webhook_job_max_retry: 3",
+                    "chart:",
+                    "  absolute_url: disabled",
+                    "trivy:",
+                    "  ignore_unfixed: false",
+                    "  offline_scan: false",
+                    "  skip_update: false",
+                ]
+            )
+            + "\n"
+        )

--- a/mlox/services/harbor/mlox.harbor.v2.14.0.yaml
+++ b/mlox/services/harbor/mlox.harbor.v2.14.0.yaml
@@ -1,0 +1,44 @@
+id: harbor-2-14-0-docker
+name: Harbor
+version: "2.14.0"
+maintainer: MLOX Contributors
+description_short: Harbor is an open source container registry that secures artifacts with policies and role based access control.
+description: |
+  Harbor provides a hardened, policy-driven container registry with role-based access control,
+  vulnerability scanning, and replication capabilities. This stack deploys Harbor using the
+  official Docker images and configures TLS termination with a self-signed certificate so you
+  can experiment with a private container registry in a secure manner.
+links:
+  project: https://goharbor.io/
+  documentation: https://goharbor.io/docs/2.14.0/install-config/
+  source: https://github.com/goharbor/harbor
+requirements:
+  cpus: 4.0
+  ram_gb: 8.0
+  disk_gb: 30.0
+groups:
+  service:
+  registry:
+  backend:
+    docker:
+ports:
+  https: 8443
+  registry: 5443
+ui:
+  settings: mlox.services.harbor.ui.settings
+build:
+  class_name: mlox.services.harbor.docker.HarborDockerService
+  params:
+    name: harbor-2-14-0
+    template: ${MLOX_STACKS_PATH}/harbor/docker-compose-harbor.yaml
+    target_path: ${MLOX_USER_HOME}/harbor-2-14-0
+    hostname: ${MLOX_SERVER_IP}
+    https_port: ${MLOX_AUTO_PORT_HTTPS}
+    registry_port: ${MLOX_AUTO_PORT_REGISTRY}
+    admin_username: admin
+    admin_password: ${MLOX_AUTO_PW}
+    database_password: ${MLOX_AUTO_PW}
+    redis_password: ${MLOX_AUTO_PW}
+    core_secret: ${MLOX_AUTO_PW}
+    jobservice_secret: ${MLOX_AUTO_PW}
+    registry_http_secret: ${MLOX_AUTO_PW}

--- a/mlox/services/harbor/ui.py
+++ b/mlox/services/harbor/ui.py
@@ -1,0 +1,43 @@
+import streamlit as st
+
+from mlox.infra import Infrastructure, Bundle
+from mlox.services.harbor.docker import HarborDockerService
+from mlox.services.utils_ui import save_to_secret_store
+
+
+def settings(infra: Infrastructure, bundle: Bundle, service: HarborDockerService) -> None:
+    st.write(f"Harbor UI: {service.service_url}")
+    st.write(f"Container registry endpoint: {service.registry_url}")
+    st.write(f"Administrator: {service.admin_username}")
+
+    save_to_secret_store(
+        infra,
+        f"MLOX_HARBOR_{service.name.upper()}",
+        {
+            "ui_url": service.service_url,
+            "registry_url": service.registry_url,
+            "username": service.admin_username,
+            "password": service.admin_password,
+        },
+    )
+
+    st.link_button(
+        "Open Harbor UI",
+        url=service.service_url,
+        icon=":material/open_in_new:",
+        help="Open the Harbor web console",
+    )
+
+    st.code(
+        f"""
+docker login {service.registry_url} \
+  --username {service.admin_username} \
+  --password {service.admin_password}
+        """.strip(),
+        language="bash",
+        line_numbers=True,
+    )
+
+    if service.certificate:
+        st.markdown("#### TLS certificate")
+        st.code(service.certificate.strip(), language="pem")

--- a/tests/integration/test_service_harbor.py
+++ b/tests/integration/test_service_harbor.py
@@ -1,0 +1,68 @@
+import pytest
+
+from mlox.config import load_config, get_stacks_path
+from mlox.infra import Infrastructure, Bundle
+
+from tests.integration.conftest import wait_for_service_ready
+
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(scope="module")
+def install_harbor_service(ubuntu_docker_server):
+    infra = Infrastructure()
+    bundle = Bundle(name=ubuntu_docker_server.ip, server=ubuntu_docker_server)
+    infra.bundles.append(bundle)
+
+    config = load_config(
+        get_stacks_path(), "/harbor", "mlox.harbor.v2.14.0.yaml"
+    )
+
+    bundle_added = infra.add_service(ubuntu_docker_server.ip, config, params={})
+    if not bundle_added:
+        pytest.skip("Failed to add Harbor service from config")
+
+    bundle = bundle_added
+    service = bundle.services[-1]
+
+    with ubuntu_docker_server.get_server_connection() as conn:
+        service.setup(conn)
+        service.spin_up(conn)
+
+    wait_for_service_ready(service, bundle, retries=10, interval=60, no_checks=True)
+
+    yield bundle_added, service
+
+    with ubuntu_docker_server.get_server_connection() as conn:
+        try:
+            service.spin_down(conn)
+        except Exception:
+            pass
+        try:
+            service.teardown(conn)
+        except Exception:
+            pass
+    infra.remove_bundle(bundle_added)
+
+
+def test_harbor_service_is_installed(install_harbor_service):
+    _, service = install_harbor_service
+    assert service.service_url
+    assert service.registry_url
+    assert service.state == "running"
+
+
+def test_harbor_service_is_running(install_harbor_service):
+    bundle, service = install_harbor_service
+
+    status = wait_for_service_ready(service, bundle, retries=5, interval=60)
+    assert status.get("status") == "running"
+
+
+def test_harbor_secrets_available(install_harbor_service):
+    _, service = install_harbor_service
+    secrets = service.get_secrets()
+    assert "harbor_admin_credentials" in secrets
+    assert secrets["harbor_admin_credentials"]["username"] == service.admin_username
+    assert secrets["harbor_admin_credentials"]["password"] == service.admin_password

--- a/tests/unit/test_service_secrets.py
+++ b/tests/unit/test_service_secrets.py
@@ -3,6 +3,7 @@ import pytest
 from mlox.services.kafka.docker import KafkaDockerService
 from mlox.services.airflow.docker import AirflowDockerService
 from mlox.services.feast.docker import FeastDockerService
+from mlox.services.harbor.docker import HarborDockerService
 from mlox.services.gcp.bq_service import GCPBigQueryService
 from mlox.services.gcp.secret_service import GCPSecretService
 from mlox.services.gcp.sheet_service import GCPSpreadsheetsService
@@ -207,6 +208,33 @@ SERVICE_CASES = [
             "minio_root_credentials": {
                 "username": "minio",
                 "password": "minio-pass",
+            },
+        },
+        None,
+    ),
+    (
+        HarborDockerService,
+        {
+            "hostname": "harbor.example.test",
+            "https_port": "8443",
+            "registry_port": "5443",
+            "admin_username": "admin",
+            "admin_password": "Harbor12345",
+            "database_password": "DbSecret123",
+            "redis_password": "RedisSecret123",
+            "core_secret": "CoreSecret123",
+            "jobservice_secret": "JobSecret123",
+            "registry_http_secret": "RegistrySecret123",
+        },
+        {
+            "harbor_admin_credentials": {
+                "username": "admin",
+                "password": "Harbor12345",
+            },
+            "harbor_registry": {
+                "hostname": "harbor.example.test",
+                "registry_url": "https://harbor.example.test:5443",
+                "certificate": "",
             },
         },
         None,


### PR DESCRIPTION
## Summary
- add a Harbor Docker Compose stack with TLS assets and configuration metadata
- expose Streamlit UI settings and integration scaffolding for the Harbor service
- extend integration coverage and update service secret tests for Harbor credentials

## Testing
- pytest tests/unit/test_service_secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68fcf0f69bd08322aff7d09553a73361