### PR TITLE
Add dedicated Firewall page for Streamlit infrastructure UI

### DIFF
--- a/mlox/app.py
+++ b/mlox/app.py
@@ -152,6 +152,11 @@ pages_infrastructure = [
         icon=":material/network_node:",
     ),
     st.Page(
+        "view/firewall.py",
+        title="Firewall",
+        icon=":material/gpp_good:",
+    ),
+    st.Page(
         "view/services.py",
         title="Services",
         icon=":material/linked_services:",

--- a/mlox/servers/ubuntu/ui_native.py
+++ b/mlox/servers/ubuntu/ui_native.py
@@ -1,92 +1,10 @@
 import streamlit as st
 
-from typing import Any, Dict, List
+from typing import Dict
 
 from mlox.config import ServiceConfig
-from mlox.executors import UbuntuTaskExecutor
 from mlox.infra import Infrastructure, Bundle
 from mlox.servers.ubuntu.native import UbuntuNativeServer
-
-
-def _collect_firewall_port_rows(
-    bundle: Bundle, server: UbuntuNativeServer
-) -> List[Dict[str, Any]]:
-    rows: List[Dict[str, Any]] = [
-        {
-            "port_number": int(server.port),
-            "service": "Server",
-            "port_name": "SSH",
-        }
-    ]
-    seen = {(int(server.port), "Server", "SSH")}
-
-    for service in bundle.services:
-        service_name = getattr(service, "name", service.__class__.__name__)
-        for port_name, port in service.service_ports.items():
-            row_key = (int(port), service_name, str(port_name))
-            if row_key in seen:
-                continue
-            seen.add(row_key)
-            rows.append(
-                {
-                    "port_number": int(port),
-                    "service": service_name,
-                    "port_name": str(port_name),
-                }
-            )
-
-    return sorted(rows, key=lambda row: (row["port_number"], row["service"]))
-
-
-def _collect_firewall_ports(bundle: Bundle, server: UbuntuNativeServer) -> List[int]:
-    return sorted(
-        {
-            row["port_number"]
-            for row in _collect_firewall_port_rows(bundle, server)
-            if row["port_number"] > 0
-        }
-    )
-
-
-def _parse_firewall_open_ports(status: str | None) -> set[int] | None:
-    return UbuntuTaskExecutor._parse_iptables_allowed_ports(status)
-
-
-def _filter_firewall_port_rows(
-    port_rows: List[Dict[str, Any]], open_ports: set[int] | None
-) -> List[Dict[str, Any]]:
-    if open_ports is None:
-        return port_rows
-
-    visible_rows = [row for row in port_rows if row["port_number"] in open_ports]
-    known_ports = {row["port_number"] for row in visible_rows}
-    visible_rows.extend(
-        {
-            "port_number": port,
-            "service": "Unknown",
-            "port_name": "iptables rule",
-        }
-        for port in sorted(open_ports - known_ports)
-    )
-    return visible_rows
-
-
-def _firewall_status_message(
-    firewall_status: str | None,
-    open_ports: set[int] | None,
-    visible_port_rows: List[Dict[str, Any]],
-) -> str | None:
-    if firewall_status and "Status: inactive" in firewall_status:
-        return "Firewall is not up. All ports are open."
-    if open_ports is None:
-        return "Could not read firewall status. Showing configured ports instead."
-    if not visible_port_rows:
-        return "No open firewall ports found."
-    return None
-
-
-def _is_firewall_up(firewall_status: str | None) -> bool:
-    return bool(firewall_status and "Status: active" in firewall_status)
 
 
 def form_add_server(sid: str):
@@ -161,43 +79,3 @@ def settings(infra: Infrastructure, bundle: Bundle, server: UbuntuNativeServer):
 
     with tab_backend:
         st.write(server.get_backend_status())
-
-    with st.expander("Firewall", expanded=False):
-        port_rows = _collect_firewall_port_rows(bundle, server)
-        firewall_status = server.firewall_status()
-        open_ports = _parse_firewall_open_ports(firewall_status)
-        visible_port_rows = _filter_firewall_port_rows(port_rows, open_ports)
-        ports = _collect_firewall_ports(bundle, server)
-        firewall_is_up = _is_firewall_up(firewall_status)
-        status_message = _firewall_status_message(
-            firewall_status, open_ports, visible_port_rows
-        )
-        if status_message:
-            st.info(status_message)
-
-        if firewall_is_up:
-            st.caption(
-                "Open firewall ports. Port name comes from the service port "
-                "registry; unmatched iptables rules are listed as unknown."
-            )
-            st.dataframe(
-                visible_port_rows,
-                use_container_width=True,
-                hide_index=True,
-                column_config={
-                    "port_number": st.column_config.NumberColumn("Port Number"),
-                    "service": st.column_config.TextColumn("Service"),
-                    "port_name": st.column_config.TextColumn("Port Name"),
-                },
-            )
-            c1, c2 = st.columns(2)
-            if c1.button("Firewall Update", type="primary"):
-                server.firewall_update(ports)
-                st.success(f"Firewall updated. Open ports: {ports}")
-            if c2.button("Firewall Down"):
-                server.firewall_down()
-                st.success("Firewall disabled.")
-        else:
-            if st.button("Firewall Up", type="primary"):
-                server.firewall_up(ports)
-                st.success(f"Firewall enabled. Open ports: {ports}")

--- a/mlox/view/firewall.py
+++ b/mlox/view/firewall.py
@@ -61,77 +61,85 @@ def _collect_firewall_port_rows(bundle: Bundle) -> List[Dict[str, Any]]:
     return sorted(rows, key=lambda row: (row["port_number"], row["service"]))
 
 
-def _parse_ports(raw: str) -> List[int]:
-    ports: set[int] = set()
-    if not raw.strip():
-        return []
-    for token in raw.replace(" ", "").split(","):
-        if not token:
+def _normalize_ip_values(values: Sequence[str]) -> list[str]:
+    seen: set[str] = set()
+    ips: list[str] = []
+    for value in values:
+        ip = str(value).strip()
+        if not ip or ip in seen:
             continue
-        if not token.isdigit():
-            raise ValueError(f"Invalid port value: {token}")
-        port = int(token)
-        if port < 1 or port > 65535:
-            raise ValueError(f"Port out of range: {port}")
-        ports.add(port)
-    return sorted(ports)
+        seen.add(ip)
+        ips.append(ip)
+    return ips
 
 
-def _parse_source_whitelist(raw: str) -> Dict[int, Sequence[str] | None]:
-    whitelist: Dict[int, Sequence[str] | None] = {}
-    if not raw.strip():
-        return whitelist
-
-    for lineno, line in enumerate(raw.splitlines(), start=1):
-        text = line.strip()
-        if not text:
-            continue
-        if ":" not in text:
-            raise ValueError(
-                f"Invalid whitelist line {lineno}: '{line}'. Use '<port>: <ip1>,<ip2>'."
-            )
-        port_text, ips_text = text.split(":", 1)
-        port = int(port_text.strip())
-        if port < 1 or port > 65535:
-            raise ValueError(f"Port out of range on line {lineno}: {port}")
-
-        ip_values = [ip.strip() for ip in ips_text.split(",") if ip.strip()]
-        whitelist[port] = ip_values or None
-
-    return whitelist
-
-
-def _source_whitelist_to_text(
+def _normalize_whitelist_state(
     source_ips_by_port: Mapping[int, Sequence[str] | None] | None,
-) -> str:
+) -> Dict[int, list[str]]:
     if not source_ips_by_port:
-        return ""
-
-    lines: List[str] = []
-    for port in sorted(source_ips_by_port):
-        ips = source_ips_by_port[port]
-        if ips:
-            lines.append(f"{port}: {', '.join(ips)}")
-    return "\n".join(lines)
+        return {}
+    return {
+        int(port): _normalize_ip_values(ips or [])
+        for port, ips in source_ips_by_port.items()
+        if _normalize_ip_values(ips or [])
+    }
 
 
-def _filter_visible_rows(
-    port_rows: List[Dict[str, Any]], open_ports: set[int] | None
+def _build_port_table_rows(
+    recommended_rows: List[Dict[str, Any]],
+    open_ports: Sequence[int],
+    whitelist_by_port: Mapping[int, Sequence[str]],
 ) -> List[Dict[str, Any]]:
-    if open_ports is None:
-        return port_rows
+    rows_by_port: Dict[int, Dict[str, set[str] | bool]] = {}
 
-    visible_rows = [row for row in port_rows if row["port_number"] in open_ports]
-    known_ports = {row["port_number"] for row in visible_rows}
-    visible_rows.extend(
-        {
-            "port_number": port,
-            "service": "Unknown",
-            "port_name": "iptables rule",
-        }
-        for port in sorted(open_ports - known_ports)
-    )
-    return visible_rows
+    for row in recommended_rows:
+        port = int(row["port_number"])
+        port_row = rows_by_port.setdefault(
+            port,
+            {"services": set(), "port_names": set(), "custom": False},
+        )
+        cast(set[str], port_row["services"]).add(str(row["service"]))
+        cast(set[str], port_row["port_names"]).add(str(row["port_name"]))
+
+    known_ports = set(rows_by_port)
+    for port in sorted({int(port) for port in open_ports}):
+        port_row = rows_by_port.setdefault(
+            int(port),
+            {"services": set(), "port_names": set(), "custom": True},
+        )
+        if port not in known_ports:
+            port_row["custom"] = True
+            cast(set[str], port_row["services"]).add("Custom")
+            cast(set[str], port_row["port_names"]).add("Custom Port")
+
+    open_port_set = {int(port) for port in open_ports}
+    table_rows: List[Dict[str, Any]] = []
+    for port in sorted(rows_by_port):
+        if port not in open_port_set:
+            continue
+        row = rows_by_port[port]
+        whitelist = _normalize_ip_values(whitelist_by_port.get(port, []))
+        table_rows.append(
+            {
+                "Port": port,
+                "Service": ", ".join(sorted(cast(set[str], row["services"]))),
+                "Port Name": ", ".join(sorted(cast(set[str], row["port_names"]))),
+                "Whitelisted IPs": whitelist,
+            }
+        )
+    return table_rows
+
+
+def _source_rules_for_open_ports(
+    open_ports: Sequence[int],
+    whitelist_by_port: Mapping[int, Sequence[str]],
+) -> Dict[int, Sequence[str]]:
+    open_port_set = {int(port) for port in open_ports}
+    return {
+        port: ips
+        for port, ips in whitelist_by_port.items()
+        if port in open_port_set and _normalize_ip_values(ips)
+    }
 
 
 def _apply_firewall(
@@ -178,7 +186,9 @@ def firewall() -> None:
         server = bundle.server
         firewall_status = server.firewall_status()
         open_ports = UbuntuTaskExecutor._parse_iptables_allowed_ports(firewall_status)
-        allowed_rules = UbuntuTaskExecutor._parse_iptables_allowed_rules(firewall_status)
+        allowed_rules = UbuntuTaskExecutor._parse_iptables_allowed_rules(
+            firewall_status
+        )
         source_by_port: Dict[int, list[str]] = {}
         if allowed_rules:
             for port, source in allowed_rules:
@@ -204,7 +214,9 @@ def firewall() -> None:
                 "Name": bundle.name,
                 "IP": server.ip,
                 "State": server.state,
-                "Firewall": "🟢 Active" if _is_firewall_up(firewall_status) else "⚪ Inactive",
+                "Firewall": "🟢 Active"
+                if _is_firewall_up(firewall_status)
+                else "⚪ Inactive",
                 "Open Ports": len(open_ports or []),
                 "Recommended": len(recommended_ports),
                 "Server UUID": server.uuid,
@@ -245,90 +257,171 @@ def firewall() -> None:
 
     st.divider()
     st.subheader(f"Firewall settings · {bundle.name} ({server.ip})")
-    st.code(firewall_status or "Could not fetch firewall status", language="bash")
+    f_is_up = _is_firewall_up(firewall_status)
+    if not f_is_up:
+        st.info("This server has no firewall enabled.")
+        if st.button("Enable Firewall", type="primary"):
+            _apply_firewall(bundle, "up", recommended_ports, None)
+            st.success(
+                f"Firewall enabled for {bundle.name} with ports: {recommended_ports}"
+            )
+            st.rerun()
+        return
 
-    visible_rows = _filter_visible_rows(recommended_rows, open_ports)
     st.caption(
-        "Known ports include SSH plus service ports. Active iptables rules outside known services are shown as 'Unknown'."
+        "Every port in the table is open. Select ports to remove or whitelist them, "
+        "or add a custom port. Changes are applied immediately."
     )
-    st.dataframe(
-        visible_rows,
+
+    current_ports = sorted(open_ports or set())
+    whitelist_by_port = _normalize_whitelist_state(source_by_port)
+    custom_port_input_key = f"firewall-custom-port-input-{server.uuid}"
+
+    if custom_port_input_key not in st.session_state:
+        st.session_state[custom_port_input_key] = 8080
+
+    table_rows = _build_port_table_rows(
+        recommended_rows,
+        current_ports,
+        whitelist_by_port,
+    )
+    port_table = pd.DataFrame(
+        table_rows,
+        columns=["Port", "Service", "Port Name", "Whitelisted IPs"],
+    )
+    selection = st.dataframe(
+        port_table,
+        key=f"firewall-port-table-{server.uuid}",
         hide_index=True,
         use_container_width=True,
+        selection_mode="multi-row",
+        on_select="rerun",
+        column_order=[
+            "Port",
+            "Service",
+            "Port Name",
+            "Whitelisted IPs",
+        ],
         column_config={
-            "port_number": st.column_config.NumberColumn("Port"),
-            "service": st.column_config.TextColumn("Service"),
-            "port_name": st.column_config.TextColumn("Port Name"),
+            "Port": st.column_config.NumberColumn("Port"),
+            "Service": st.column_config.TextColumn("Service"),
+            "Port Name": st.column_config.TextColumn("Port Name"),
+            "Whitelisted IPs": st.column_config.ListColumn(
+                "Whitelisted IPs",
+                help="Source IPs or CIDRs allowed for this port. Empty means open to any source.",
+            ),
         },
     )
 
-    ports_key = f"firewall-ports-{server.uuid}"
-    whitelist_key = f"firewall-whitelist-{server.uuid}"
-    if ports_key not in st.session_state:
-        seeded_ports = sorted(set(recommended_ports) | set(open_ports or set()))
-        st.session_state[ports_key] = ", ".join(str(port) for port in seeded_ports)
-    if whitelist_key not in st.session_state:
-        st.session_state[whitelist_key] = _source_whitelist_to_text(source_by_port)
+    selected_indexes = selection.get("selection", {}).get("rows", [])
+    selected_ports = [int(table_rows[index]["Port"]) for index in selected_indexes]
 
-    st.markdown("#### Port Controls")
-    st.text_input(
-        "Allowed ports (comma-separated)",
-        key=ports_key,
-        help="Example: 22, 80, 443, 5000",
+    st.markdown("#### Selected Ports")
+    selected_label = (
+        f"Selected: {', '.join(str(port) for port in selected_ports)}"
+        if selected_ports
+        else "No ports selected"
     )
+    st.caption(selected_label)
 
-    quick_port_key = f"firewall-quick-port-{server.uuid}"
-    if quick_port_key not in st.session_state:
-        st.session_state[quick_port_key] = 8080
-    q1, q2, q3 = st.columns([2, 1, 1])
-    q1.number_input(
-        "Quick custom port",
-        key=quick_port_key,
+    if st.button(
+        "Remove Selected Ports",
+        disabled=not selected_ports,
+    ):
+        selected_port_set = set(selected_ports)
+        next_ports = [port for port in current_ports if port not in selected_port_set]
+        next_whitelist = _source_rules_for_open_ports(
+            next_ports,
+            whitelist_by_port,
+        )
+        _apply_firewall(
+            bundle,
+            "update",
+            next_ports,
+            next_whitelist or None,
+        )
+        st.success(f"Removed ports: {sorted(selected_port_set)}")
+        st.rerun()
+
+    current_ip_options = sorted(
+        {ip for ips in whitelist_by_port.values() for ip in _normalize_ip_values(ips)}
+    )
+    selected_ip_defaults = sorted(
+        {
+            ip
+            for port in selected_ports
+            for ip in _normalize_ip_values(whitelist_by_port.get(port, []))
+        }
+    )
+    selected_port_token = "-".join(str(port) for port in selected_ports) or "none"
+    selected_ips_key = f"firewall-selected-ips-{server.uuid}-{selected_port_token}"
+    st.markdown("#### Whitelist Selected Ports")
+    w1, w2 = st.columns([3, 1], vertical_alignment="bottom")
+    selected_ips = w1.multiselect(
+        "Source IPs or CIDRs",
+        options=sorted(set(current_ip_options) | set(selected_ip_defaults)),
+        default=selected_ip_defaults,
+        accept_new_options=True,
+        disabled=not selected_ports,
+        placeholder="Add IPs or CIDRs",
+        help="Applies the same whitelist to every selected port. Empty allows any source.",
+        key=selected_ips_key,
+    )
+    if w2.button(
+        "Apply Whitelist",
+        disabled=not selected_ports,
+        use_container_width=True,
+    ):
+        updated_whitelist = dict(whitelist_by_port)
+        ips = _normalize_ip_values(selected_ips)
+        for port in selected_ports:
+            if ips:
+                updated_whitelist[port] = ips
+            else:
+                updated_whitelist.pop(port, None)
+        next_whitelist = _source_rules_for_open_ports(
+            current_ports,
+            updated_whitelist,
+        )
+        _apply_firewall(
+            bundle,
+            "update",
+            current_ports,
+            next_whitelist or None,
+        )
+        st.success(f"Updated whitelist for ports: {selected_ports}")
+        st.rerun()
+
+    st.markdown("#### Add Custom Port")
+    c1, c2 = st.columns([1, 1], vertical_alignment="bottom")
+    c1.number_input(
+        "Port",
+        key=custom_port_input_key,
         min_value=1,
         max_value=65535,
         step=1,
     )
-    if q2.button("Open Port", type="primary", use_container_width=True):
-        ports = _parse_ports(st.session_state[ports_key])
-        ports = sorted(set(ports) | {int(st.session_state[quick_port_key])})
-        st.session_state[ports_key] = ", ".join(str(port) for port in ports)
-        st.rerun()
-    if q3.button("Close Port", use_container_width=True):
-        ports = _parse_ports(st.session_state[ports_key])
-        ports = [p for p in ports if p != int(st.session_state[quick_port_key])]
-        st.session_state[ports_key] = ", ".join(str(port) for port in ports)
-        st.rerun()
-
-    st.markdown("#### Source IP Whitelist (optional)")
-    st.text_area(
-        "Per-port whitelist",
-        key=whitelist_key,
-        help="One line per port. Format: '<port>: <ip-or-cidr>[, <ip-or-cidr>]'. Example: '22: 10.0.0.5/32'.",
-        height=120,
-    )
-
-    parsed_ports: List[int] = []
-    parsed_whitelist: Dict[int, Sequence[str] | None] = {}
-    try:
-        parsed_ports = _parse_ports(st.session_state[ports_key])
-        parsed_whitelist = _parse_source_whitelist(st.session_state[whitelist_key])
-    except ValueError as exc:
-        st.error(str(exc))
-
-    f_is_up = _is_firewall_up(firewall_status)
-    b1, b2, b3 = st.columns(3)
-    if b1.button("Enable Firewall", type="primary", disabled=f_is_up):
-        _apply_firewall(bundle, "up", parsed_ports, parsed_whitelist or None)
-        st.success(f"Firewall enabled for {bundle.name} with ports: {parsed_ports}")
+    if c2.button("Add Port", type="primary", use_container_width=True):
+        custom_port = int(st.session_state[custom_port_input_key])
+        next_ports = sorted(set(current_ports) | {custom_port})
+        next_whitelist = _source_rules_for_open_ports(
+            next_ports,
+            whitelist_by_port,
+        )
+        _apply_firewall(
+            bundle,
+            "update",
+            next_ports,
+            next_whitelist or None,
+        )
+        st.success(f"Added port: {custom_port}")
         st.rerun()
 
-    if b2.button("Update Rules", type="primary", disabled=not f_is_up):
-        _apply_firewall(bundle, "update", parsed_ports, parsed_whitelist or None)
-        st.success(f"Firewall updated for {bundle.name}. Allowed ports: {parsed_ports}")
-        st.rerun()
+    with st.expander("Raw firewall status"):
+        st.code(firewall_status or "Could not fetch firewall status", language="bash")
 
-    if b3.button("Disable Firewall", disabled=not f_is_up):
-        _apply_firewall(bundle, "down", parsed_ports, parsed_whitelist or None)
+    if st.button("Disable Firewall"):
+        _apply_firewall(bundle, "down", current_ports, whitelist_by_port or None)
         st.success(f"Firewall disabled for {bundle.name}.")
         st.rerun()
 

--- a/mlox/view/firewall.py
+++ b/mlox/view/firewall.py
@@ -1,0 +1,336 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Mapping, Sequence, cast
+
+import pandas as pd
+import streamlit as st
+
+from mlox.executors import UbuntuTaskExecutor
+from mlox.infra import Bundle, Infrastructure
+from mlox.server import ServerCapability
+
+
+st.markdown(
+    """
+    <style>
+    div[data-testid="stMetric"] {
+      background: rgba(56, 149, 97, 0.12);
+      border: 1px solid rgba(46, 139, 87, 0.6);
+      border-radius: 16px;
+      padding: 10px;
+    }
+    div[data-testid="stMetric"] label {color:#cbd5e1}
+    div[data-testid="stMetricValue"] {color:#2E8B57}
+    div[data-testid="stMetricValue"] * {color:#2E8B57 !important}
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
+
+
+def _is_firewall_up(firewall_status: str | None) -> bool:
+    return bool(firewall_status and "Status: active" in firewall_status)
+
+
+def _collect_firewall_port_rows(bundle: Bundle) -> List[Dict[str, Any]]:
+    server = bundle.server
+    rows: List[Dict[str, Any]] = [
+        {
+            "port_number": int(server.port),
+            "service": "Server",
+            "port_name": "SSH",
+        }
+    ]
+    seen = {(int(server.port), "Server", "SSH")}
+
+    for service in bundle.services:
+        service_name = getattr(service, "name", service.__class__.__name__)
+        for port_name, port in service.service_ports.items():
+            row_key = (int(port), service_name, str(port_name))
+            if row_key in seen:
+                continue
+            seen.add(row_key)
+            rows.append(
+                {
+                    "port_number": int(port),
+                    "service": service_name,
+                    "port_name": str(port_name),
+                }
+            )
+
+    return sorted(rows, key=lambda row: (row["port_number"], row["service"]))
+
+
+def _parse_ports(raw: str) -> List[int]:
+    ports: set[int] = set()
+    if not raw.strip():
+        return []
+    for token in raw.replace(" ", "").split(","):
+        if not token:
+            continue
+        if not token.isdigit():
+            raise ValueError(f"Invalid port value: {token}")
+        port = int(token)
+        if port < 1 or port > 65535:
+            raise ValueError(f"Port out of range: {port}")
+        ports.add(port)
+    return sorted(ports)
+
+
+def _parse_source_whitelist(raw: str) -> Dict[int, Sequence[str] | None]:
+    whitelist: Dict[int, Sequence[str] | None] = {}
+    if not raw.strip():
+        return whitelist
+
+    for lineno, line in enumerate(raw.splitlines(), start=1):
+        text = line.strip()
+        if not text:
+            continue
+        if ":" not in text:
+            raise ValueError(
+                f"Invalid whitelist line {lineno}: '{line}'. Use '<port>: <ip1>,<ip2>'."
+            )
+        port_text, ips_text = text.split(":", 1)
+        port = int(port_text.strip())
+        if port < 1 or port > 65535:
+            raise ValueError(f"Port out of range on line {lineno}: {port}")
+
+        ip_values = [ip.strip() for ip in ips_text.split(",") if ip.strip()]
+        whitelist[port] = ip_values or None
+
+    return whitelist
+
+
+def _source_whitelist_to_text(
+    source_ips_by_port: Mapping[int, Sequence[str] | None] | None,
+) -> str:
+    if not source_ips_by_port:
+        return ""
+
+    lines: List[str] = []
+    for port in sorted(source_ips_by_port):
+        ips = source_ips_by_port[port]
+        if ips:
+            lines.append(f"{port}: {', '.join(ips)}")
+    return "\n".join(lines)
+
+
+def _filter_visible_rows(
+    port_rows: List[Dict[str, Any]], open_ports: set[int] | None
+) -> List[Dict[str, Any]]:
+    if open_ports is None:
+        return port_rows
+
+    visible_rows = [row for row in port_rows if row["port_number"] in open_ports]
+    known_ports = {row["port_number"] for row in visible_rows}
+    visible_rows.extend(
+        {
+            "port_number": port,
+            "service": "Unknown",
+            "port_name": "iptables rule",
+        }
+        for port in sorted(open_ports - known_ports)
+    )
+    return visible_rows
+
+
+def _apply_firewall(
+    bundle: Bundle,
+    action: str,
+    ports: Sequence[int],
+    source_ips_by_port: Mapping[int, Sequence[str] | None] | None,
+) -> None:
+    server = bundle.server
+    if action == "up":
+        server.firewall_up(ports, source_ips_by_port)
+    elif action == "update":
+        server.firewall_update(ports, source_ips_by_port)
+    elif action == "down":
+        server.firewall_down()
+
+
+def firewall() -> None:
+    st.title("Firewall")
+    st.caption(
+        "Manage host-level firewall rules for servers that expose firewall capabilities. "
+        "You can enable/disable firewall protection, open/close custom ports, and whitelist source IPs per port."
+    )
+
+    try:
+        infra = cast(Infrastructure, st.session_state.mlox.infra)
+    except BaseException:
+        st.error("Could not load infrastructure configuration.")
+        st.stop()
+
+    bundles_with_firewall = [
+        bundle
+        for bundle in infra.bundles
+        if ServerCapability.FIREWALL in getattr(bundle.server, "capabilities", set())
+    ]
+
+    if not bundles_with_firewall:
+        st.info("No servers with firewall capability detected in this project.")
+        return
+
+    rows: List[Dict[str, Any]] = []
+    details_by_server: Dict[str, Dict[str, Any]] = {}
+    for bundle in bundles_with_firewall:
+        server = bundle.server
+        firewall_status = server.firewall_status()
+        open_ports = UbuntuTaskExecutor._parse_iptables_allowed_ports(firewall_status)
+        allowed_rules = UbuntuTaskExecutor._parse_iptables_allowed_rules(firewall_status)
+        source_by_port: Dict[int, list[str]] = {}
+        if allowed_rules:
+            for port, source in allowed_rules:
+                if source is None:
+                    continue
+                source_by_port.setdefault(port, [])
+                if source not in source_by_port[port]:
+                    source_by_port[port].append(source)
+
+        recommended_rows = _collect_firewall_port_rows(bundle)
+        recommended_ports = sorted({row["port_number"] for row in recommended_rows})
+
+        details_by_server[server.uuid] = {
+            "bundle": bundle,
+            "firewall_status": firewall_status,
+            "open_ports": open_ports,
+            "recommended_rows": recommended_rows,
+            "recommended_ports": recommended_ports,
+            "source_by_port": source_by_port,
+        }
+        rows.append(
+            {
+                "Name": bundle.name,
+                "IP": server.ip,
+                "State": server.state,
+                "Firewall": "🟢 Active" if _is_firewall_up(firewall_status) else "⚪ Inactive",
+                "Open Ports": len(open_ports or []),
+                "Recommended": len(recommended_ports),
+                "Server UUID": server.uuid,
+            }
+        )
+
+    active_count = sum(1 for r in rows if r["Firewall"] == "🟢 Active")
+    c1, c2, c3 = st.columns(3)
+    c1.metric("Firewall-capable Servers", len(rows))
+    c2.metric("Firewalls Active", active_count)
+    c3.metric("Firewalls Inactive", len(rows) - active_count)
+
+    df = pd.DataFrame(rows)
+    selection = st.dataframe(
+        df[["Name", "IP", "State", "Firewall", "Open Ports", "Recommended"]],
+        hide_index=True,
+        use_container_width=True,
+        selection_mode="single-row",
+        on_select="rerun",
+    )
+
+    selected_rows = selection.get("selection", {}).get("rows", [])
+    if not selected_rows:
+        st.info("Select a server from the table to manage firewall rules.")
+        return
+
+    selected_idx = selected_rows[0]
+    selected_uuid = rows[selected_idx]["Server UUID"]
+    selected_details = details_by_server[selected_uuid]
+    bundle = selected_details["bundle"]
+    server = bundle.server
+
+    firewall_status = selected_details["firewall_status"]
+    open_ports = selected_details["open_ports"]
+    recommended_rows = selected_details["recommended_rows"]
+    recommended_ports = selected_details["recommended_ports"]
+    source_by_port = selected_details["source_by_port"]
+
+    st.divider()
+    st.subheader(f"Firewall settings · {bundle.name} ({server.ip})")
+    st.code(firewall_status or "Could not fetch firewall status", language="bash")
+
+    visible_rows = _filter_visible_rows(recommended_rows, open_ports)
+    st.caption(
+        "Known ports include SSH plus service ports. Active iptables rules outside known services are shown as 'Unknown'."
+    )
+    st.dataframe(
+        visible_rows,
+        hide_index=True,
+        use_container_width=True,
+        column_config={
+            "port_number": st.column_config.NumberColumn("Port"),
+            "service": st.column_config.TextColumn("Service"),
+            "port_name": st.column_config.TextColumn("Port Name"),
+        },
+    )
+
+    ports_key = f"firewall-ports-{server.uuid}"
+    whitelist_key = f"firewall-whitelist-{server.uuid}"
+    if ports_key not in st.session_state:
+        seeded_ports = sorted(set(recommended_ports) | set(open_ports or set()))
+        st.session_state[ports_key] = ", ".join(str(port) for port in seeded_ports)
+    if whitelist_key not in st.session_state:
+        st.session_state[whitelist_key] = _source_whitelist_to_text(source_by_port)
+
+    st.markdown("#### Port Controls")
+    st.text_input(
+        "Allowed ports (comma-separated)",
+        key=ports_key,
+        help="Example: 22, 80, 443, 5000",
+    )
+
+    quick_port_key = f"firewall-quick-port-{server.uuid}"
+    if quick_port_key not in st.session_state:
+        st.session_state[quick_port_key] = 8080
+    q1, q2, q3 = st.columns([2, 1, 1])
+    q1.number_input(
+        "Quick custom port",
+        key=quick_port_key,
+        min_value=1,
+        max_value=65535,
+        step=1,
+    )
+    if q2.button("Open Port", type="primary", use_container_width=True):
+        ports = _parse_ports(st.session_state[ports_key])
+        ports = sorted(set(ports) | {int(st.session_state[quick_port_key])})
+        st.session_state[ports_key] = ", ".join(str(port) for port in ports)
+        st.rerun()
+    if q3.button("Close Port", use_container_width=True):
+        ports = _parse_ports(st.session_state[ports_key])
+        ports = [p for p in ports if p != int(st.session_state[quick_port_key])]
+        st.session_state[ports_key] = ", ".join(str(port) for port in ports)
+        st.rerun()
+
+    st.markdown("#### Source IP Whitelist (optional)")
+    st.text_area(
+        "Per-port whitelist",
+        key=whitelist_key,
+        help="One line per port. Format: '<port>: <ip-or-cidr>[, <ip-or-cidr>]'. Example: '22: 10.0.0.5/32'.",
+        height=120,
+    )
+
+    parsed_ports: List[int] = []
+    parsed_whitelist: Dict[int, Sequence[str] | None] = {}
+    try:
+        parsed_ports = _parse_ports(st.session_state[ports_key])
+        parsed_whitelist = _parse_source_whitelist(st.session_state[whitelist_key])
+    except ValueError as exc:
+        st.error(str(exc))
+
+    f_is_up = _is_firewall_up(firewall_status)
+    b1, b2, b3 = st.columns(3)
+    if b1.button("Enable Firewall", type="primary", disabled=f_is_up):
+        _apply_firewall(bundle, "up", parsed_ports, parsed_whitelist or None)
+        st.success(f"Firewall enabled for {bundle.name} with ports: {parsed_ports}")
+        st.rerun()
+
+    if b2.button("Update Rules", type="primary", disabled=not f_is_up):
+        _apply_firewall(bundle, "update", parsed_ports, parsed_whitelist or None)
+        st.success(f"Firewall updated for {bundle.name}. Allowed ports: {parsed_ports}")
+        st.rerun()
+
+    if b3.button("Disable Firewall", disabled=not f_is_up):
+        _apply_firewall(bundle, "down", parsed_ports, parsed_whitelist or None)
+        st.success(f"Firewall disabled for {bundle.name}.")
+        st.rerun()
+
+
+firewall()


### PR DESCRIPTION
### Motivation
- Centralize firewall management into a dedicated UI page instead of burying controls inside individual server settings. 
- Make it easy to enable/disable host firewall protection, open/close custom ports, and configure per-port source-IP whitelists across servers that support firewall capabilities. 

### Description
- Added a new Streamlit page `mlox/view/firewall.py` that lists servers advertising the `firewall` capability and provides a dashboard-style UI with metrics, selectable server table, firewall status, visible open ports, recommended ports, editable allowed-port input, quick open/close port controls, per-port whitelist editor, and actions that call the existing backend APIs (`firewall_up`, `firewall_update`, `firewall_down`).
- Implemented parsing and validation helpers for comma-separated ports (`_parse_ports`) and per-port whitelist lines (`_parse_source_whitelist`) plus conversions to/from text for session-state seeding.
- Preserved existing iptables parsing by reusing `UbuntuTaskExecutor._parse_iptables_allowed_ports` and `_parse_iptables_allowed_rules` to show known vs unknown/open rules.
- Wired the new page into the app navigation by adding `view/firewall.py` to the infrastructure pages in `mlox/app.py`.
- Removed the in-place firewall expander and related helper code from `mlox/servers/ubuntu/ui_native.py` so firewall management is centralized in the new page.

### Testing
- Compiled modified UI modules with `python -m compileall mlox/view/firewall.py mlox/servers/ubuntu/ui_native.py mlox/app.py` and the compilation completed successfully. 
- Ran unit tests for firewall executor behavior with `pytest -q tests/unit/test_executors_firewall.py` and all tests passed (`10 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0b6321aa483229ac56fdf52e02f4e)